### PR TITLE
Comment out pinentryFlavor

### DIFF
--- a/nixpkgs/services.nix
+++ b/nixpkgs/services.nix
@@ -5,6 +5,7 @@
     enable = true;
     enableSshSupport = true;
     defaultCacheTtl = 1800;
-    pinentryFlavor = "tty";
+    # tty does not work, so comment out
+    #pinentryFlavor = "tty";
   };
 }


### PR DESCRIPTION
tty does not work on NixOS, so comment it out to use the default. Pinentry does not work over SSH, but this is better than a totally broken setting.