### PR TITLE
Switch to home-manager 23.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM nixos/nix:2.9.0@sha256:13b257cd42db29dc851f9818ea1bc2f9c7128c51fdf000971fa6
 
 WORKDIR "/home/nshang"
 
-RUN nix-channel --add https://github.com/nix-community/home-manager/archive/release-23.05.tar.gz home-manager && \
+# HM 23.11
+RUN nix-channel --add https://github.com/nix-community/home-manager/archive/release-23.11.tar.gz home-manager && \
   nix-channel --update && \
   nix-env --install home-manager
 


### PR DESCRIPTION
Test configurations against newly released HM 23.11 in Docker.