### PR TITLE
GHA: upgrade to actions/checkout v4.1.1

### DIFF
--- a/.github/workflows/build-hm-pkgs.yml
+++ b/.github/workflows/build-hm-pkgs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Test in Docker"
         run: |
           set -euxo pipefail


### PR DESCRIPTION
Move away from the now deprecated node 12.