### PR TITLE
home-manager: add some C development related pkgs

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -29,6 +29,10 @@
     pkgs.pari
     pkgs.vlc
     pkgs.shellcheck
+    pkgs.cmake
+    pkgs.clang
+    pkgs.autoconf
+    pkgs.automake
   ];
   # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;


### PR DESCRIPTION
Add `cmake`, `clang`, `autoconf` and `automake`.