### PR TITLE
Fix home manager services gpg-agent pinentry config

### DIFF
--- a/home-manager/services.nix
+++ b/home-manager/services.nix
@@ -5,7 +5,6 @@
     enable = true;
     enableSshSupport = true;
     defaultCacheTtl = 1800;
-    # tty does not work, so comment out
-    #pinentryFlavor = "tty";
+    pinentryPackage = pkgs.pinentry-tty;
   };
 }


### PR DESCRIPTION
Use pkgs.pinentry-tty.