### PR TITLE
GHA: update actions/checkout to v6.0.2

### DIFF
--- a/.github/workflows/build-hm-pkgs.yml
+++ b/.github/workflows/build-hm-pkgs.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4.1.1
+        # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: "Test in Docker"
         run: |
           set -euxo pipefail

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR "/home/nshang"
 # HM 23.11
 RUN nix-channel --add https://github.com/nix-community/home-manager/archive/release-23.11.tar.gz home-manager && \
   nix-channel --update && \
-  nix-env --install home-manager
+  nix-env --install home-manager && \
+  home-manager --version
 
 COPY . "/home/nshang/nix-dotfiles"
 


### PR DESCRIPTION
Use the corresponding commit SHA for versioning.